### PR TITLE
Fixed Docker Imaging Challenges

### DIFF
--- a/challanges/devops/docker-imaging/beginner-challenge-1/python-hello-world/Dockerfile
+++ b/challanges/devops/docker-imaging/beginner-challenge-1/python-hello-world/Dockerfile
@@ -1,5 +1,4 @@
-FROM python:3
-
+FROM localhost:32000/python:3
 COPY . .
-RUN pip install -r requirements.txt
+RUN pip install --index-url http://172.17.0.1:32001/simple --trusted-host 172.17.0.1 -r requirements.txt
 CMD python hello-world.py

--- a/challanges/devops/docker-imaging/beginner-challenge-1/story.md
+++ b/challanges/devops/docker-imaging/beginner-challenge-1/story.md
@@ -50,6 +50,4 @@ CMD python hello-world.py
 
 And viola! Hello World from a container!
 Notice the difference in the output when running inside a container? 
-To-Do:
-(Turn this into a flag somehow)
 

--- a/challanges/devops/docker-imaging/enable_validator.sh
+++ b/challanges/devops/docker-imaging/enable_validator.sh
@@ -1,0 +1,1 @@
+sudo ln -s /vagrant/challanges/devops/docker-imaging/tsvalidator /usr/local/bin/

--- a/challanges/devops/docker-imaging/enable_validator.sh
+++ b/challanges/devops/docker-imaging/enable_validator.sh
@@ -1,1 +1,1 @@
-sudo ln -s /vagrant/challanges/devops/docker-imaging/tsvalidator /usr/local/bin/
+alias tsvalidator="sudo DOCKER_HOST=unix:///var/snap/microk8s/362/docker.sock /vagrant/challanges/devops/docker-imaging/tsvalidator"

--- a/challanges/devops/docker-imaging/hard-challenge-1/Dockerfile
+++ b/challanges/devops/docker-imaging/hard-challenge-1/Dockerfile
@@ -1,0 +1,5 @@
+FROM localhost:32000/tchaudhry/alpine-curl-gzip
+RUN curl -o access.log.gz http://172.17.0.1:32002/access.log.gz
+RUN gzip -d access.log.gz
+RUN cat access.log | cut -f 1 -d " " | sort | uniq > unique-access.log
+RUN rm access.log

--- a/challanges/devops/docker-imaging/intermediate-challenge-1/python-hello-worlds/Dockerfile
+++ b/challanges/devops/docker-imaging/intermediate-challenge-1/python-hello-worlds/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3
+FROM localhost:32000/python:3
 
 COPY . .
-RUN pip install -r requirements.txt
+RUN pip install --index http://172.17.0.1:32001/simple --trusted-host 172.17.0.1 -r requirements.txt 
 CMD python hello-worlds.py

--- a/challanges/devops/docker-imaging/intermediate-challenge-1/python-hello-worlds/hello-worlds.py
+++ b/challanges/devops/docker-imaging/intermediate-challenge-1/python-hello-worlds/hello-worlds.py
@@ -13,5 +13,5 @@ def is_docker():
     return False
 
 if __name__ == "__main__":
-    print("Hello Worlds!! from {}!".format(os.getpid()))
+    print("Hello Wrlds!! from {}!".format(os.getpid()))
     print("Running in Docker: {}".format(is_docker()))

--- a/challanges/devops/docker-imaging/intermediate-challenge-1/story.md
+++ b/challanges/devops/docker-imaging/intermediate-challenge-1/story.md
@@ -23,5 +23,3 @@ So you read up on docker image layers. Apparently, each instruction in the Docke
 TASK: Change the Dockerfile so that subsequent changes to the code are built quickly and do not have to gather the requirements everytime!
 
 HINT: Try copying your app into the container in 2 different steps.
-
-TO-DO: Figure out how to get a flag again!

--- a/challanges/devops/docker-imaging/intermediate-challenge-2/python-hello-worlds/Dockerfile
+++ b/challanges/devops/docker-imaging/intermediate-challenge-2/python-hello-worlds/Dockerfile
@@ -1,0 +1,5 @@
+FROM localhost:32000/python:3
+
+COPY . .
+RUN pip install --index http://172.17.0.1:32001/simple --trusted-host 172.17.0.1 -r requirements.txt 
+CMD python hello-worlds.py

--- a/challanges/devops/docker-imaging/intermediate-challenge-2/python-hello-worlds/hello-worlds.py
+++ b/challanges/devops/docker-imaging/intermediate-challenge-2/python-hello-worlds/hello-worlds.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+
+import os, re
+
+path = os.path.join("/proc/" + str(os.getpid()) + "/cgroup")
+
+def is_docker():
+  if not os.path.isfile(path): return False
+  with open(path) as f:
+    for line in f:
+      if re.match("\d+:[\w=]+:/docker(-[ce]e)?/\w+", line):
+        return True
+    return False
+
+if __name__ == "__main__":
+    print("Hello Wrlds!! from {}!".format(os.getpid()))
+    print("Running in Docker: {}".format(is_docker()))

--- a/challanges/devops/docker-imaging/intermediate-challenge-2/python-hello-worlds/requirements.txt
+++ b/challanges/devops/docker-imaging/intermediate-challenge-2/python-hello-worlds/requirements.txt
@@ -1,0 +1,2 @@
+# This is not really required, but it's making a point
+requests

--- a/challanges/devops/docker-imaging/intermediate-challenge-2/story.md
+++ b/challanges/devops/docker-imaging/intermediate-challenge-2/story.md
@@ -9,7 +9,7 @@ It's a hello-world app. What kind of bloat do they think is there??
   NINE HUNDRED AND THIRY ONE MEGABYTES. You can wash your eyes all you want, but this number is correct.
 
 - Step 2: You do some math. < 1KB of code. ~10Mb of requirement library. Hmm. Definitely != 900+ MB. What about the base image? That's also a layer. Perhaps that's where the bloat is? Let's take a look.
-  `docker images python:3`
+  `docker images localhost:32000/python:3`
 
 - Step 3: The previous step should have made it clear by now. You need to choose your `FROM` statement carefully. The system contains a couple of pre-baked images on your system that can be used instead of `python:3`. Look them up with:
   `docker images -a | grep python`

--- a/docs/content/docker-imaging/challenge1.md
+++ b/docs/content/docker-imaging/challenge1.md
@@ -4,12 +4,17 @@ weight = 5
 +++
 
 ### Hello World
+First a little bit of setup, run the following command to get a local pypi server that will serve dependencies for our app:
+`cd /vagrant/tools/vagrant/pypi/ && ./start.sh && cd -`
 
-Let's dockerize a hello-world app! Grab the python-hello-world repository and try running the python example in it.
+And enable the validator : `/vagrant/challanges/devops/docker-imaging/enable_validator.sh`
+
+Now, let's dockerize a hello-world app! Grab the python-hello-world repository and try running the python example in it.
+
 
 ```bash
-pip install -r requirements.txt
-python hello-world.py
+pip3 install --index http://172.17.0.1:32001/simple --trusted-host 172.17.0.1 -r requirements.txt
+python3 hello-world.py
 ```
 (yes, 4 years on a rock and tutorials still do 'hello-world', disappointing)
 
@@ -20,7 +25,7 @@ python hello-world.py
 
 Every Dockerfile must start with a `FROM` statement. This signifies the beginning point for an image. Almost always, we are building on top of something. Our app is python. So, let's grab a python based image to start from:
 
-`FROM python:3`
+`FROM localhost:32000/python:3`
 
 So, we already have a base image with everything python needs to run in it. Let's `COPY` our super fancy code to it.
 
@@ -29,7 +34,7 @@ So, we already have a base image with everything python needs to run in it. Let'
 What's left? We have the interpreter, we have the code. Let's `RUN` the dependency gathering.
 (Note: This app doesn't really need the dependency, but we've put it in here to explain the RUN command)
 
-`RUN pip install -r requirements.txt`
+`RUN pip --index http://172.17.0.1:32001/simple --trusted-host 172.17.0.1 -r requirements.txt`
 
 Now, tell the container what `COMMAND` to run when it's started.
 
@@ -38,7 +43,7 @@ Now, tell the container what `COMMAND` to run when it's started.
 Here's what the final Dockerfile should look like!
 
 ```Docker
-FROM python:3
+FROM localhost:32000/python:3
 COPY . .
 RUN pip install -r requirements.txt
 CMD python hello-world.py
@@ -60,17 +65,4 @@ Notice the difference in the output when running inside a container?
 
 #### Run the following command to get your flag after you have executed your docker build instruction!
 
-`tsvalidator validate docker chal1 --image hello-world-python`
-
-
-#### Conclusion
-
-And that brings you to the end of this hands on session - you learned how to deploy a container, expose it outside the cluster, scale it up and upgrade it. All without any impact to the service
-availability.
-
-Clean up your cluster by doing these steps:
-
-`kubectl delete -f deployment.yaml`
-
-`kubectl delete -f service.yaml`
-
+`sudo DOCKER_HOST=unix:///var/snap/microk8s/362/docker.sock tsvalidator validate docker chal1 --image hello-world-python`

--- a/docs/content/docker-imaging/challenge1.md
+++ b/docs/content/docker-imaging/challenge1.md
@@ -65,4 +65,4 @@ Notice the difference in the output when running inside a container?
 
 #### Run the following command to get your flag after you have executed your docker build instruction!
 
-`sudo DOCKER_HOST=unix:///var/snap/microk8s/362/docker.sock tsvalidator validate docker chal1 --image hello-world-python`
+`tsvalidator validate docker chal1 --image hello-world-python`

--- a/docs/content/docker-imaging/challenge2.md
+++ b/docs/content/docker-imaging/challenge2.md
@@ -38,5 +38,7 @@ HINT: Try copying your app into the container in 2 different steps.
 
 #### FLAG:
 
-`tsvalidator validate docker chal2 --image hello-world-python`
+`sudo DOCKER_HOST=unix:///var/snap/microk8s/362/docker.sock tsvalidator validate docker chal2 --image hello-worlds-python`
+
+NOTE: If you didn't complete this step in the first challenge, enable the validator now : `/vagrant/challanges/devops/docker-imaging/enable_validator.sh`
 

--- a/docs/content/docker-imaging/challenge2.md
+++ b/docs/content/docker-imaging/challenge2.md
@@ -38,7 +38,7 @@ HINT: Try copying your app into the container in 2 different steps.
 
 #### FLAG:
 
-`sudo DOCKER_HOST=unix:///var/snap/microk8s/362/docker.sock tsvalidator validate docker chal2 --image hello-worlds-python`
+`tsvalidator validate docker chal2 --image hello-worlds-python`
 
 NOTE: If you didn't complete this step in the first challenge, enable the validator now : `/vagrant/challanges/devops/docker-imaging/enable_validator.sh`
 

--- a/docs/content/docker-imaging/challenge3.md
+++ b/docs/content/docker-imaging/challenge3.md
@@ -47,7 +47,7 @@ Re-check the size of your image and post the output:
 
 #### FLAG:
 
-`sudo DOCKER_HOST=unix:///var/snap/microk8s/362/docker.sock tsvalidator validate docker chal3 --image hello-world-python:slim`
+`tsvalidator validate docker chal3 --image hello-world-python:slim`
 
 NOTE: If you didn't complete this step in the first challenge, enable the validator now : `/vagrant/challanges/devops/docker-imaging/enable_validator.sh`
 

--- a/docs/content/docker-imaging/challenge3.md
+++ b/docs/content/docker-imaging/challenge3.md
@@ -27,11 +27,11 @@ hello-worlds-python     latest  927fb8d8ac54    24 minutes ago  931MB
 
 You do some math. < 1KB of code. ~10Mb of requirement library. Hmm. Definitely != 900+ MB. What about the base image? That's also a layer. Perhaps that's where the bloat is? Let's take a look.
 
-`docker images python:3`
+`docker images localhost:32000/python:3`
 
 #### Step 3: Smaller alternatives
 
-The previous step should have made it clear by now. You need to choose your `FROM` statement carefully. The system contains a couple of pre-baked images on your system that can be used instead of `python:3`. Look them up with:
+The previous step should have made it clear by now. You need to choose your `FROM` statement carefully. The system contains a couple of pre-baked images on your system that can be used instead of `localhost:32000/python:3`. Look them up with:
 
 `docker images -a | grep python`
 
@@ -47,5 +47,7 @@ Re-check the size of your image and post the output:
 
 #### FLAG:
 
-`tsvalidator validate docker chal3 --image hello-world-python --tag slim`
+`sudo DOCKER_HOST=unix:///var/snap/microk8s/362/docker.sock tsvalidator validate docker chal3 --image hello-world-python:slim`
+
+NOTE: If you didn't complete this step in the first challenge, enable the validator now : `/vagrant/challanges/devops/docker-imaging/enable_validator.sh`
 

--- a/docs/content/docker-imaging/challenge4.md
+++ b/docs/content/docker-imaging/challenge4.md
@@ -28,6 +28,6 @@ SETUP : Run the following command: `cd /vagrant/tools/vagrant/filehost/ && ./sta
 TASK: Rewrite the above Dockerfile so that it still contains the `/unique-access.log` but is as small as possible. There are multiple ways to achieve this and we only care about the final result. You get credit as long as your final image is as small as it can be.
 
 #### Run the following command to get your flag after you have created a new image < 10Mb
-`sudo DOCKER_HOST=unix:///var/snap/microk8s/362/docker.sock tsvalidator validate docker chal4 --image {your-image-name}`
+`tsvalidator validate docker chal4 --image {your-image-name}`
 
 NOTE: If you didn't complete this step in the first challenge, enable the validator now : `/vagrant/challanges/devops/docker-imaging/enable_validator.sh`

--- a/docs/content/docker-imaging/challenge4.md
+++ b/docs/content/docker-imaging/challenge4.md
@@ -13,11 +13,9 @@ Try your hand at this challenge:
 > Hello, I have a Dockerfile in which I do the following things:
 >
 > ```Docker
-FROM alpine
-RUN apk add --update curl
-RUN rm -rf /var/cache/apk/*
-RUN curl -o access.log http://www.almhuette-raith.at/apache-log/access.log
-*** Note to TechSummit Team: Replace with a custom localhost url once added to base build image ***
+FROM localhost:32000/alpine-curl-gzip
+RUN curl -o access.log.gz http://172.17.0.1:32002/access.log.gz
+RUN gzip -d access.log.gz
 RUN cat access.log | cut -f 1 -d " " | sort | uniq > unique-access.log
 RUN rm access.log
 ```
@@ -25,11 +23,11 @@ RUN rm access.log
 > I'm trying to gather the unique list of IPs from a very large apache log. While the unique list is very small, the final docker image is very large! I even used a small alpine base image!
 > Can someone help me optimize this?
 
-TASK: Rewrite the above Dockerfile so that it still contains the unique `access.log` but is as small as possible. There are multiple ways to achieve this and we only care about the final result. You get credit as long as your final image is as small as it can be.
+SETUP : Run the following command: `cd /vagrant/tools/vagrant/filehost/ && ./start.sh && cd -`
 
+TASK: Rewrite the above Dockerfile so that it still contains the `/unique-access.log` but is as small as possible. There are multiple ways to achieve this and we only care about the final result. You get credit as long as your final image is as small as it can be.
 
-HINTS:
+#### Run the following command to get your flag after you have created a new image < 10Mb
+`sudo DOCKER_HOST=unix:///var/snap/microk8s/362/docker.sock tsvalidator validate docker chal4 --image {your-image-name}`
 
-  - multistage build
-  - chained run statements
-  - script into one layer
+NOTE: If you didn't complete this step in the first challenge, enable the validator now : `/vagrant/challanges/devops/docker-imaging/enable_validator.sh`

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -15,4 +15,5 @@ Vagrant.configure("2") do |config|
    end
   config.vm.provision "shell", path: "provision_scripts/setup_k8s.sh"
   config.vm.provision "shell", path: "provision_scripts/create_local_registry.sh"
+  config.vm.provision "shell", path: "provision_scripts/install_python.sh"
 end

--- a/tools/vagrant/filehost/deployment.yaml
+++ b/tools/vagrant/filehost/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: filehost
+  labels:
+    app: filehost
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: filehost
+  template:
+    metadata:
+      labels:
+        app: filehost
+    spec:
+      containers:
+      - name: filehost
+        image: localhost:32000/tchaudhry/http-access-logs:master
+        ports:
+        - containerPort: 80

--- a/tools/vagrant/filehost/service.yaml
+++ b/tools/vagrant/filehost/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata: 
+  name: filehost-web
+spec: 
+  ports: 
+     -  port: 12002
+        protocol: TCP
+        targetPort: 80
+        nodePort: 32002
+  selector: 
+    app: filehost
+  type: NodePort

--- a/tools/vagrant/filehost/start.sh
+++ b/tools/vagrant/filehost/start.sh
@@ -1,0 +1,3 @@
+# Deploy PyPi
+kubectl apply -f deployment.yaml
+kubectl apply -f service.yaml

--- a/tools/vagrant/provision_scripts/create_local_registry.sh
+++ b/tools/vagrant/provision_scripts/create_local_registry.sh
@@ -12,8 +12,13 @@ saykumar/ts2019:l2s2
 tchaudhry/hash-svc:ts2019blue
 tchaudhry/hash-svc:ts2019red
 tchaudhry/simple-http-load:master
+tchaudhry/pypi:master
+tchaudhry/http-access-logs:master
+tchaudhry/alpine-curl-gzip
 prom/prometheus
 python:3
+python:3-slim
+python:3-alpine
 alpine:3.7
 vault
 ubuntu:bionic

--- a/tools/vagrant/provision_scripts/install_python.sh
+++ b/tools/vagrant/provision_scripts/install_python.sh
@@ -1,0 +1,3 @@
+set -e
+apt -y update
+apt -y install python3 python3-pip

--- a/tools/vagrant/pypi/deployment.yaml
+++ b/tools/vagrant/pypi/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pypi-server
+  labels:
+    app: pypi-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pypi-server
+  template:
+    metadata:
+      labels:
+        app: pypi-server
+    spec:
+      containers:
+      - name: pypi
+        image: localhost:32000/tchaudhry/pypi:master
+        env:
+        - name: PYPI_ROOT
+          value: "/srv/pypi_custom"
+        ports:
+        - containerPort: 80

--- a/tools/vagrant/pypi/service.yaml
+++ b/tools/vagrant/pypi/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata: 
+  name: pypi-web
+spec: 
+  ports: 
+     -  port: 12000
+        protocol: TCP
+        targetPort: 80
+        nodePort: 32001
+  selector: 
+    app: pypi-server
+  type: NodePort

--- a/tools/vagrant/pypi/start.sh
+++ b/tools/vagrant/pypi/start.sh
@@ -1,0 +1,3 @@
+# Deploy PyPi
+kubectl apply -f deployment.yaml
+kubectl apply -f service.yaml


### PR DESCRIPTION
This is a big one. 
I've tried to adhere to all the vagrant standards in the base image.
Two new services:
- pypi server to serve dependencies for python (custom image)
- nginx to serve the apache logs for challenge4

Everything now runs inside the box and no internet is needed.
I have also attached the validator binary along (we can add it at provision time as well if you say).

I do not expect any merge conflicts expect in the local_registry builder. I which case too it should be an easy fix.

I have tested all of these without internet in a refreshed Vagrant box. All of them work.
All necessary changes have been pushed into the docs + stories.

